### PR TITLE
fix: use the new Flutter 3.7.0 maybeOf to avoid a possible crash

### DIFF
--- a/lib/src/handle.dart
+++ b/lib/src/handle.dart
@@ -132,13 +132,13 @@ class _HandleState extends State<Handle> {
   Widget build(BuildContext context) {
     if (!widget.enabled) return widget.child;
 
-    _list = ImplicitlyAnimatedReorderableList.of(context);
+    _list = ImplicitlyAnimatedReorderableList.maybeOf(context);
     assert(_list != null,
         'No ancestor ImplicitlyAnimatedReorderableList was found in the hierarchy!');
-    _reorderable = Reorderable.of(context);
+    _reorderable = Reorderable.maybeOf(context);
     assert(_reorderable != null,
         'No ancestor Reorderable was found in the hierarchy!');
-    _parent = Scrollable.of(_list!.context);
+    _parent = Scrollable.maybeOf(_list!.context);
 
     // Sometimes the cancel callbacks of the GestureDetector
     // are erroneously invoked. Use a plain Listener instead

--- a/lib/src/implicitly_animated_reorderable_list.dart
+++ b/lib/src/implicitly_animated_reorderable_list.dart
@@ -195,7 +195,7 @@ class ImplicitlyAnimatedReorderableList<E extends Object>
   ImplicitlyAnimatedReorderableListState<E> createState() =>
       ImplicitlyAnimatedReorderableListState<E>();
 
-  static ImplicitlyAnimatedReorderableListState? of(BuildContext context) {
+  static ImplicitlyAnimatedReorderableListState? maybeOf(BuildContext context) {
     return context
         .findAncestorStateOfType<ImplicitlyAnimatedReorderableListState>();
   }

--- a/lib/src/reorderable.dart
+++ b/lib/src/reorderable.dart
@@ -46,7 +46,7 @@ class Reorderable extends StatefulWidget {
   @override
   ReorderableState createState() => ReorderableState();
 
-  static ReorderableState? of(BuildContext context) {
+  static ReorderableState? maybeOf(BuildContext context) {
     return context.findAncestorStateOfType<ReorderableState>();
   }
 }
@@ -96,7 +96,7 @@ class ReorderableState extends State<Reorderable>
   }
 
   void _registerItem() {
-    final list = ImplicitlyAnimatedReorderableList.of(context)!;
+    final list = ImplicitlyAnimatedReorderableList.maybeOf(context)!;
 
     list.registerItem(this);
     _dragController.duration = list.widget.settleDuration;


### PR DESCRIPTION
Flutter 3.7.0 introduced a breaking change where the `.of(` now returns a non null values or an exception. If you want to keep the previous behavior, we need to use `.maybeOf(`.

This PR use that new maybeOf to avoid a possible crash in this lib.