### PR TITLE
Run test matrix from 3.7.0 until 3.7.3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [3.7.3, 3.3.10, 3.0.0]
+        version: [3.7.0, 3.7.3]
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       flutter_channel: "stable"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,9 +8,13 @@ on:
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [3.7.3, 3.3.10, 3.0.0]
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       flutter_channel: "stable"
-      flutter_version: "3.7.0"
+      flutter_version: ${{ matrix.version }}
       test_recursion: true
       min_coverage: 0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/wwwdata/implicitly_animated_reorderable_list
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=3.5.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   async: ^2.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/wwwdata/implicitly_animated_reorderable_list
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=3.0.0"
+  flutter: ">=3.7.0"
 
 dependencies:
   async: ^2.8.1


### PR DESCRIPTION
To actually check nothing breaks for older versions. So we can find out when something is unsupported and we need to bump the minimum supported version for this package.

The minimum version is now set to 3.7.0 because of deprecations in the Flutter Framework