### PR TITLE
Add `clipBehavior` argument to constructors.

### DIFF
--- a/lib/src/implicitly_animated_list.dart
+++ b/lib/src/implicitly_animated_list.dart
@@ -124,6 +124,11 @@ class ImplicitlyAnimatedList<E extends Object> extends StatelessWidget {
   /// The amount of space by which to inset the children.
   final EdgeInsetsGeometry? padding;
 
+  /// The clip behavior to be used by the scroll view.
+  ///
+  /// Defaults to [Clip.hardEdge].
+  final Clip clipBehavior;
+
   /// Creates a Flutter ListView that implicitly animates between the changes
   /// of two lists.
   const ImplicitlyAnimatedList({
@@ -145,6 +150,7 @@ class ImplicitlyAnimatedList<E extends Object> extends StatelessWidget {
     this.physics,
     this.shrinkWrap = false,
     this.padding,
+    this.clipBehavior = Clip.hardEdge,
   }) : super(key: key);
 
   @override
@@ -158,6 +164,7 @@ class ImplicitlyAnimatedList<E extends Object> extends StatelessWidget {
       primary: primary,
       physics: physics,
       shrinkWrap: shrinkWrap,
+      clipBehavior: clipBehavior,
       slivers: <Widget>[
         SliverPadding(
           padding: padding ?? const EdgeInsets.all(0),

--- a/lib/src/implicitly_animated_reorderable_list.dart
+++ b/lib/src/implicitly_animated_reorderable_list.dart
@@ -77,6 +77,11 @@ class ImplicitlyAnimatedReorderableList<E extends Object>
   /// The amount of space by which to inset the children.
   final EdgeInsetsGeometry? padding;
 
+  /// The clip behavior to be used by the scroll view.
+  ///
+  /// Defaults to [Clip.hardEdge].
+  final Clip clipBehavior;
+
   /// The duration of the animation when an item is being translated
   /// to a new position in the list, i.e. when the item is reordered.
   final Duration reorderDuration;
@@ -168,6 +173,7 @@ class ImplicitlyAnimatedReorderableList<E extends Object>
     this.physics,
     this.shrinkWrap = false,
     this.padding,
+    this.clipBehavior = Clip.hardEdge,
     this.reorderDuration = const Duration(milliseconds: 300),
     this.onReorderStarted,
     required this.onReorderFinished,
@@ -239,6 +245,7 @@ class ImplicitlyAnimatedReorderableList<E extends Object>
     this.physics,
     this.shrinkWrap = false,
     this.padding,
+    this.clipBehavior = Clip.hardEdge,
     this.reorderDuration = const Duration(milliseconds: 300),
     this.onReorderStarted,
     required this.onReorderFinished,
@@ -741,6 +748,7 @@ class ImplicitlyAnimatedReorderableListState<E extends Object>
       primary: widget.primary,
       reverse: widget.reverse,
       shrinkWrap: widget.shrinkWrap,
+      clipBehavior: widget.clipBehavior,
       slivers: <Widget>[
         if (hasHeader)
           SliverToBoxAdapter(


### PR DESCRIPTION
`CustomScrollView`'s default clip behavior is `Clip.hardEdge`, which is not always desirable. This adds a `clipBehavior` argument to the constructors for `ImplicitlyAnimatedList` and `ImplicitlyAnimatedReorderableList` that is then passed on to `CustomScrollView`'s constructor.